### PR TITLE
Infinite Scroll Components

### DIFF
--- a/vendor/assets/javascripts/neat/lib/paginated_list.js
+++ b/vendor/assets/javascripts/neat/lib/paginated_list.js
@@ -74,6 +74,10 @@ Lail.PaginatedList = function(list, options) {
     return self.set;
   }
 
+  this.getCurrentSetCumulative = function() {
+    return self.set.slice(0, self.lastItemIndex());
+  }
+
   function renderPagination() {
     if(self.pagination_container) {
       self.pagination_container.html(self.renderPagination());


### PR DESCRIPTION
As it is, the `CollectionEditor` only works well when **a)** the entire collection is already loaded into memory and **b)** the collection is displayed with "hard" pagination. These modifications attempt to address both **a** and **b** by allowing for an external trigger to call in to dynamically fetch more models into the collection AND by giving the option to append the results dynamically to the collection view.
