### PR TITLE
Added overridable context method to model editor

### DIFF
--- a/vendor/assets/javascripts/neat/model_editor.coffee
+++ b/vendor/assets/javascripts/neat/model_editor.coffee
@@ -31,8 +31,7 @@ class window.Neat.ModelEditor extends Backbone.View
       @edit() if @canEdit() and !$(e.target).isIn('input, button, a, label')
 
   render: ->
-    json = _.extend(@model.toJSON(), {options: @templateOptions})
-    @$el.html @template()(json)
+    @$el.html @template()(@context())
     @$el.attr('id', "#{@resource}_#{@model.get('id')}") # e.g. "calendar_5"
 
     @afterRender()
@@ -94,6 +93,9 @@ class window.Neat.ModelEditor extends Backbone.View
 
   okToSave: (attributes)->
     true
+
+  context: ->
+    _.extend(@model.toJSON(), {options: @templateOptions})
 
   attributesFromForm: ($el) ->
     attrs = {}


### PR DESCRIPTION
This allows subclasses of `ModelEditor` to tweak the Handlebars context without having to override the `render()` method.
