### PR TITLE
Added debouncing to default renderer's _render method

### DIFF
--- a/vendor/assets/javascripts/neat/renderer/basic.coffee
+++ b/vendor/assets/javascripts/neat/renderer/basic.coffee
@@ -8,6 +8,7 @@ class window.Neat.Renderer.Basic
     @collection.bind 'change',  @_modelHasBeenChanged, @
     @views = []
     @observer = new Observer()
+    @renderTimeout = null
 
   renderTo: (@$ul) ->
     @views = []
@@ -21,8 +22,12 @@ class window.Neat.Renderer.Basic
 
   _render: ->
     # Doesn't need to render anything else like pagination controls on the view
-    # Just needs the @$ul that it should render views to
-    @_renderVisibleModels()
+    # Just needs the @$ul that it should render views to.
+    # Debounce render calls, esp. when adding lots of models very quickly.
+    clearTimeout(@renderTimeout)
+    @renderTimeout = setTimeout =>
+      @_renderVisibleModels()
+    , 100
 
   _renderVisibleModels: ->
     visibleModels = @_visibleModels()


### PR DESCRIPTION
Keeps initial `@collection.fetch()` from firing off as many calls to `_renderVisibleModels()` as there are models in the fetched collection. Also will affect the InfiniteScroll renderer, but _not_ the Paginated renderer (since it reimplements `_render()` entirely).
