### PR TITLE
Return a boolean in `_loadMore` for if there are more items to load

### DIFF
--- a/vendor/assets/javascripts/neat/renderer/infinite_reveal.coffee
+++ b/vendor/assets/javascripts/neat/renderer/infinite_reveal.coffee
@@ -21,6 +21,7 @@ class window.Neat.Renderer.InfiniteReveal extends window.Neat.Renderer.Basic
     Neat.logger.log "[Neat.Renderer.InfiniteReveal] loading..."
     @_setMaxItems @maxItems + @pageSize
     @_renderVisibleModels()
+    @_thereIsMore()
 
   _thereIsMore: ->
     @collection.length > @maxItems


### PR DESCRIPTION
In Members we use the `_loadMore` method as an action and a check of the return value which sounds appropriate. Load more and the return value is "are there more to load".

This change allows the action to happen and returns the check.

If you feel this is incorrect, I can try making a change in Members.